### PR TITLE
Added Duration Refresh on action, before block locking

### DIFF
--- a/public/constants.js
+++ b/public/constants.js
@@ -84,6 +84,7 @@ export const ENTRY_DELAY = 6;
 export const LINE_CLEAR_FRAMES = 20;
 export const LOCK_ANIMATION_FRAMES = 15;
 export const HARDDROP_ANIMATION_FRAMES = 2;
+export const ACTION_LOCKDELAY_REFRESH_MAX = 16;
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ENUMS~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 


### PR DESCRIPTION
1.  constant.js에 ACTION_LOCKDELAY_REFRESH_MAX = 16 (뿌테 최대치) 를 추가하였습니다.

2. TetPlayer.js 의 PHASE.FALL 에서 블록을 Lock하는 부분에서, 바닥에 닿은 상태로 스핀 또는 이동 액션을 취하였을 경우 락 딜레이를 리셋시켰고, 리프레시 카운트를 1씩 올려 최대 ACTION_LOCKDELAY_REFRESH_MAX 횟수만큼만 리셋이 가능하게 하였습니다.
